### PR TITLE
Remove 2 annotations for agent launch

### DIFF
--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -10954,16 +10954,6 @@
         </tr>
         <tr>
           <td>
-            <dfn>Clear
-              Breach of Good Faith - Element Annotation</dfn>
-          </td>
-          <td>Clear Breach of Good Faith - Element Annotation</td>
-          <td>Annotation</td>
-          <td>This element refers to an action by the Star, or entities acting on its behalf, that undermines
-            trust, integrity, or fair dealing, such as deception or unethical conduct.</td>
-        </tr>
-        <tr>
-          <td>
             <dfn>Clearly
               Delineated Processes and Frameworks - Element Annotation</dfn>
           </td>
@@ -11493,17 +11483,6 @@
           <td>This element refers to situations where the Scope Facilitator is unable to perform their role due to
             reasons such as illness, conflict of interest, temporary suspension, or any other circumstance that
             significantly impairs their ability to execute their responsibilities.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Partial
-              Responsibility - Element Annotation</dfn>
-          </td>
-          <td>Partial Responsibility - Element Annotation</td>
-          <td>Annotation</td>
-          <td>This element clarifies that the Facilitator cannot choose to manage only certain parts of a Scope or
-            limit their responsibility to specific tasks. They must accept the full responsibilities and manage
-            the Scope as a whole.</td>
         </tr>
         <tr>
           <td>

--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -11167,7 +11167,7 @@
           </td>
           <td>Ecosystem - Element Annotation</td>
           <td>Annotation</td>
-          <td>The element "Ecosystem" in the phrase "Ecosystem Agreements" should be understood as the
+          <td>The element "Ecosystem" in the phrase "Ecosystem Accords" should be understood as the
             collaborative network in which multiple stakeholders (referred to as "Ecosystem Actors") interact to
             conduct business operations benefiting Sky.</td>
         </tr>


### PR DESCRIPTION
Removing 2 annotations since their target documents no longer exist in the Atlas 